### PR TITLE
Align with latest wasm naming convention

### DIFF
--- a/generator/preamble.py
+++ b/generator/preamble.py
@@ -5,9 +5,9 @@ from wasm.model import (
     Func,
     Memory,
     Global,
-    GetGlobal,
-    GetLocal,
-    SetGlobal,
+    GlobalGet,
+    LocalGet,
+    GlobalSet,
     Instruction,
     BinaryOperation,
     Const,
@@ -44,8 +44,8 @@ def preamble() -> List[Instruction]:
         result=Result(type="i32"),
         export=None,
         instructions=[
-            GetGlobal(name="$heap_pointer"),
-            SetGlobal(
+            GlobalGet(name="$heap_pointer"),
+            GlobalSet(
                 name="$heap_pointer",
                 val=(
                     BinaryOperation(
@@ -54,10 +54,10 @@ def preamble() -> List[Instruction]:
                             BinaryOperation(
                                 op="i32.mul",
                                 left=(Const(type="i32", val="4")),
-                                right=GetLocal(name="$required_bytes"),
+                                right=LocalGet(name="$required_bytes"),
                             )
                         ),
-                        right=GetGlobal(name="$heap_pointer"),
+                        right=GlobalGet(name="$heap_pointer"),
                     )
                 ),
             ),

--- a/tests/snapshots/snap_test_full_compiler.py
+++ b/tests/snapshots/snap_test_full_compiler.py
@@ -25,7 +25,7 @@ snapshots['test_simple_expression 1'] = '''(module
             (i32.add
                 (i32.mul
                     (i32.const 4)
-                    (get_local $required_bytes)
+                    (local.get $required_bytes)
                 )
                 (global.get $heap_pointer)
             )
@@ -65,7 +65,7 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
             (i32.add
                 (i32.mul
                     (i32.const 4)
-                    (get_local $required_bytes)
+                    (local.get $required_bytes)
                 )
                 (global.get $heap_pointer)
             )
@@ -84,14 +84,14 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
                 (global.get $self_pointer)
                 (i32.const 0)
             )
-            (get_local $x)
+            (local.get $x)
         )
         (i32.store
             (i32.add
                 (global.get $self_pointer)
                 (i32.const 4)
             )
-            (get_local $y)
+            (local.get $y)
         )
         (global.get $self_pointer)
     )
@@ -102,7 +102,7 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
             (i32.add
                 (i32.load
                     (i32.add
-                        (get_local $self)
+                        (local.get $self)
                         (i32.mul
                             (i32.const 0)
                             (i32.const 4)
@@ -111,7 +111,7 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
                 )
                 (i32.load
                     (i32.add
-                        (get_local $other)
+                        (local.get $other)
                         (i32.mul
                             (i32.const 0)
                             (i32.const 4)
@@ -122,7 +122,7 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
             (i32.add
                 (i32.load
                     (i32.add
-                        (get_local $self)
+                        (local.get $self)
                         (i32.mul
                             (i32.const 1)
                             (i32.const 4)
@@ -131,7 +131,7 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
                 )
                 (i32.load
                     (i32.add
-                        (get_local $other)
+                        (local.get $other)
                         (i32.mul
                             (i32.const 1)
                             (i32.const 4)
@@ -145,7 +145,7 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
     (func $Vector.getX (param $self i32) (result i32)
         (i32.load
             (i32.add
-                (get_local $self)
+                (local.get $self)
                 (i32.mul
                     (i32.const 0)
                     (i32.const 4)
@@ -157,7 +157,7 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
     (func $Vector.getY (param $self i32) (result i32)
         (i32.load
             (i32.add
-                (get_local $self)
+                (local.get $self)
                 (i32.mul
                     (i32.const 1)
                     (i32.const 4)
@@ -170,39 +170,39 @@ snapshots['test_data_vector_with_complex_function 1'] = '''(module
         (local $vectorA i32)
         (local $vectorB i32)
         (local $vectorC i32)
-        (set_local $vectorA
+        (local.set $vectorA
             (call
                 $Vector.new
                 (i32.const 3)
                 (i32.const 6)
             )
         )
-        (set_local $vectorB
+        (local.set $vectorB
             (call
                 $Vector.new
                 (i32.const 5)
                 (i32.const 3)
             )
         )
-        (set_local $vectorC
+        (local.set $vectorC
             (call
                 $Vector.add
-                (get_local $vectorA)
-                (get_local $vectorB)
+                (local.get $vectorA)
+                (local.get $vectorB)
             )
         )
         (call
             $output_println
             (call
                 $Vector.getX
-                (get_local $vectorC)
+                (local.get $vectorC)
             )
         )
         (call
             $output_println
             (call
                 $Vector.getY
-                (get_local $vectorC)
+                (local.get $vectorC)
             )
         )
     )

--- a/tests/snapshots/snap_test_preamble.py
+++ b/tests/snapshots/snap_test_preamble.py
@@ -24,7 +24,7 @@ snapshots['test_preamble 1'] = '''(module
             (i32.add
                 (i32.mul
                     (i32.const 4)
-                    (get_local $required_bytes)
+                    (local.get $required_bytes)
                 )
                 (global.get $heap_pointer)
             )

--- a/tests/snapshots/snap_test_wasm_printing.py
+++ b/tests/snapshots/snap_test_wasm_printing.py
@@ -45,30 +45,30 @@ snapshots['test_function_call_with_params_and_locals 1'] = '''(module
     (func $output_println (import "System::Output" "println") (param i32))
     (func $add (param $a i32) (param $b i32) (result i32)
         (local $answer i32)
-        (set_local $answer
+        (local.set $answer
             (i32.add
-                (get_local $a)
-                (get_local $b)
+                (local.get $a)
+                (local.get $b)
             )
         )
-        (get_local $answer)
+        (local.get $answer)
     )
 
     (func $Main (export "Main")
         (local $a i32)
         (local $b i32)
-        (set_local $a
+        (local.set $a
             (i32.const 2)
         )
-        (set_local $b
+        (local.set $b
             (i32.const 3)
         )
         (call
             $output_println
             (call
                 $add
-                (get_local $a)
-                (get_local $b)
+                (local.get $a)
+                (local.get $b)
             )
         )
     )

--- a/tests/test_wasm_code_generation.py
+++ b/tests/test_wasm_code_generation.py
@@ -10,14 +10,14 @@ from wasm.model import (
     Param,
     Const,
     Local,
-    SetLocal,
-    GetLocal,
+    LocalSet,
+    LocalGet,
     Result,
     If,
     Return,
     Import,
-    SetGlobal,
-    GetGlobal,
+    GlobalSet,
+    GlobalGet,
     Store,
     Load,
 )
@@ -119,15 +119,15 @@ def test_simple_assignment():
                     locals=[Local(type="i32", name="$a"), Local(type="i32", name="$b")],
                     result=Result(type=None),
                     instructions=[
-                        SetLocal(name="$a", val=Const(type="i32", val="5")),
-                        SetLocal(name="$b", val=Const(type="i32", val="10")),
+                        LocalSet(name="$a", val=Const(type="i32", val="5")),
+                        LocalSet(name="$b", val=Const(type="i32", val="10")),
                         Call(
                             name="$output_println",
                             arguments=[
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetLocal(name="$a"),
-                                    right=GetLocal(name="$b"),
+                                    left=LocalGet(name="$a"),
+                                    right=LocalGet(name="$b"),
                                 )
                             ],
                         ),
@@ -225,8 +225,8 @@ def test_function_call_with_arguments():
                     instructions=[
                         BinaryOperation(
                             op="i32.add",
-                            left=GetLocal(name="$x"),
-                            right=GetLocal(name="$y"),
+                            left=LocalGet(name="$x"),
+                            right=LocalGet(name="$y"),
                         )
                     ],
                 ),
@@ -412,7 +412,7 @@ def test_factorial():
                         If(
                             condition=BinaryOperation(
                                 op="i32.eq",
-                                left=GetLocal(name="$n"),
+                                left=LocalGet(name="$n"),
                                 right=Const(type="i32", val="1"),
                             ),
                             result=Result(type=None),
@@ -424,14 +424,14 @@ def test_factorial():
                                     expression=(
                                         BinaryOperation(
                                             op="i32.mul",
-                                            left=GetLocal(name="$n"),
+                                            left=LocalGet(name="$n"),
                                             right=(
                                                 Call(
                                                     name="$factorial",
                                                     arguments=[
                                                         BinaryOperation(
                                                             op="i32.sub",
-                                                            left=GetLocal(name="$n"),
+                                                            left=LocalGet(name="$n"),
                                                             right=Const(
                                                                 type="i32", val="1"
                                                             ),
@@ -505,8 +505,8 @@ def test_simple_predicates():
                     instructions=[
                         BinaryOperation(
                             op="i32.gt_s",
-                            left=GetLocal(name="$left"),
-                            right=GetLocal(name="$right"),
+                            left=LocalGet(name="$left"),
+                            right=LocalGet(name="$right"),
                         )
                     ],
                     result=Result(type="i32"),
@@ -522,8 +522,8 @@ def test_simple_predicates():
                     instructions=[
                         BinaryOperation(
                             op="i32.lt_s",
-                            left=GetLocal(name="$left"),
-                            right=GetLocal(name="$right"),
+                            left=LocalGet(name="$left"),
+                            right=LocalGet(name="$right"),
                         )
                     ],
                     result=Result(type="i32"),
@@ -539,8 +539,8 @@ def test_simple_predicates():
                     instructions=[
                         BinaryOperation(
                             op="i32.and",
-                            left=GetLocal(name="$left"),
-                            right=GetLocal(name="$right"),
+                            left=LocalGet(name="$left"),
+                            right=LocalGet(name="$right"),
                         )
                     ],
                     result=Result(type="i32"),
@@ -556,8 +556,8 @@ def test_simple_predicates():
                     instructions=[
                         BinaryOperation(
                             op="i32.or",
-                            left=GetLocal(name="$left"),
-                            right=GetLocal(name="$right"),
+                            left=LocalGet(name="$left"),
+                            right=LocalGet(name="$right"),
                         )
                     ],
                     result=Result(type="i32"),
@@ -598,7 +598,7 @@ def test_data_vector():
                     result=Result(type="i32"),
                     locals=[],
                     instructions=[
-                        SetGlobal(
+                        GlobalSet(
                             name="$self_pointer",
                             val=Call(
                                 name="$malloc", arguments=[Const(type="i32", val="2")]
@@ -608,21 +608,21 @@ def test_data_vector():
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetGlobal(name="$self_pointer"),
+                                left=GlobalGet(name="$self_pointer"),
                                 right=Const(type="i32", val="0"),
                             ),
-                            val=GetLocal(name="$x"),
+                            val=LocalGet(name="$x"),
                         ),
                         Store(
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetGlobal(name="$self_pointer"),
+                                left=GlobalGet(name="$self_pointer"),
                                 right=Const(type="i32", val="4"),
                             ),
-                            val=GetLocal(name="$y"),
+                            val=LocalGet(name="$y"),
                         ),
-                        GetGlobal(name="$self_pointer"),
+                        GlobalGet(name="$self_pointer"),
                     ],
                 ),
                 Func(
@@ -669,7 +669,7 @@ def test_data_vector_constructor():
                     params=[Param(type="i32", name="$x"), Param(type="i32", name="$y")],
                     result=Result(type="i32"),
                     instructions=[
-                        SetGlobal(
+                        GlobalSet(
                             name="$self_pointer",
                             val=Call(
                                 name="$malloc", arguments=[Const(type="i32", val="2")]
@@ -680,24 +680,24 @@ def test_data_vector_constructor():
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="0"),
                                 )
                             ),
-                            val=GetLocal(name="$x"),
+                            val=LocalGet(name="$x"),
                         ),
                         Store(
                             type="i32",
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="4"),
                                 )
                             ),
-                            val=GetLocal(name="$y"),
+                            val=LocalGet(name="$y"),
                         ),
-                        GetGlobal(name="$self_pointer"),
+                        GlobalGet(name="$self_pointer"),
                     ],
                 ),
                 Func(
@@ -707,7 +707,7 @@ def test_data_vector_constructor():
                     params=[],
                     locals=[Local(type="i32", name="$vector")],
                     instructions=[
-                        SetLocal(
+                        LocalSet(
                             name="$vector",
                             val=Call(
                                 name="$Vector.new",
@@ -759,7 +759,7 @@ def test_data_vector_with_simple_function():
                     result=Result(type="i32"),
                     locals=[],
                     instructions=[
-                        SetGlobal(
+                        GlobalSet(
                             name="$self_pointer",
                             val=Call(
                                 name="$malloc", arguments=[Const(type="i32", val="2")]
@@ -770,24 +770,24 @@ def test_data_vector_with_simple_function():
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="0"),
                                 )
                             ),
-                            val=GetLocal(name="$x"),
+                            val=LocalGet(name="$x"),
                         ),
                         Store(
                             type="i32",
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="4"),
                                 )
                             ),
-                            val=GetLocal(name="$y"),
+                            val=LocalGet(name="$y"),
                         ),
-                        GetGlobal(name="$self_pointer"),
+                        GlobalGet(name="$self_pointer"),
                     ],
                 ),
                 Func(
@@ -847,7 +847,7 @@ def test_data_vector_with_simple_function_call():
                     result=Result(type="i32"),
                     locals=[],
                     instructions=[
-                        SetGlobal(
+                        GlobalSet(
                             name="$self_pointer",
                             val=Call(
                                 name="$malloc", arguments=[Const(type="i32", val="2")]
@@ -858,24 +858,24 @@ def test_data_vector_with_simple_function_call():
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="0"),
                                 )
                             ),
-                            val=GetLocal(name="$x"),
+                            val=LocalGet(name="$x"),
                         ),
                         Store(
                             type="i32",
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="4"),
                                 )
                             ),
-                            val=GetLocal(name="$y"),
+                            val=LocalGet(name="$y"),
                         ),
-                        GetGlobal(name="$self_pointer"),
+                        GlobalGet(name="$self_pointer"),
                     ],
                 ),
                 Func(
@@ -893,7 +893,7 @@ def test_data_vector_with_simple_function_call():
                     locals=[Local(type="i32", name="$vector")],
                     result=Result(type=None),
                     instructions=[
-                        SetLocal(
+                        LocalSet(
                             name="$vector",
                             val=Call(
                                 name="$Vector.new",
@@ -908,7 +908,7 @@ def test_data_vector_with_simple_function_call():
                             arguments=[
                                 Call(
                                     name="$Vector.length",
-                                    arguments=[GetLocal(name="$vector")],
+                                    arguments=[LocalGet(name="$vector")],
                                 )
                             ],
                         ),
@@ -955,7 +955,7 @@ def test_data_vector_with_self_getter_method():
                     result=Result(type="i32"),
                     locals=[],
                     instructions=[
-                        SetGlobal(
+                        GlobalSet(
                             name="$self_pointer",
                             val=Call(
                                 name="$malloc", arguments=[Const(type="i32", val="2")]
@@ -966,24 +966,24 @@ def test_data_vector_with_self_getter_method():
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="0"),
                                 )
                             ),
-                            val=GetLocal(name="$x"),
+                            val=LocalGet(name="$x"),
                         ),
                         Store(
                             type="i32",
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="4"),
                                 )
                             ),
-                            val=GetLocal(name="$y"),
+                            val=LocalGet(name="$y"),
                         ),
-                        GetGlobal(name="$self_pointer"),
+                        GlobalGet(name="$self_pointer"),
                     ],
                 ),
                 Func(
@@ -997,7 +997,7 @@ def test_data_vector_with_self_getter_method():
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetLocal("$self"),
+                                left=LocalGet("$self"),
                                 right=BinaryOperation(
                                     op="i32.mul",
                                     left=Const(type="i32", val="0"),
@@ -1014,7 +1014,7 @@ def test_data_vector_with_self_getter_method():
                     locals=[Local(name="$vector", type="i32")],
                     result=Result(type=None),
                     instructions=[
-                        SetLocal(
+                        LocalSet(
                             name="$vector",
                             val=Call(
                                 name="$Vector.new",
@@ -1029,7 +1029,7 @@ def test_data_vector_with_self_getter_method():
                             arguments=[
                                 Call(
                                     name="$Vector.getX",
-                                    arguments=[GetLocal(name="$vector")],
+                                    arguments=[LocalGet(name="$vector")],
                                 )
                             ],
                         ),
@@ -1081,7 +1081,7 @@ def test_data_vector_with_self_getter_methods():
                     result=Result(type="i32"),
                     locals=[],
                     instructions=[
-                        SetGlobal(
+                        GlobalSet(
                             name="$self_pointer",
                             val=Call(
                                 name="$malloc", arguments=[Const(type="i32", val="2")]
@@ -1092,24 +1092,24 @@ def test_data_vector_with_self_getter_methods():
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="0"),
                                 )
                             ),
-                            val=GetLocal(name="$x"),
+                            val=LocalGet(name="$x"),
                         ),
                         Store(
                             type="i32",
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="4"),
                                 )
                             ),
-                            val=GetLocal(name="$y"),
+                            val=LocalGet(name="$y"),
                         ),
-                        GetGlobal(name="$self_pointer"),
+                        GlobalGet(name="$self_pointer"),
                     ],
                 ),
                 Func(
@@ -1123,7 +1123,7 @@ def test_data_vector_with_self_getter_methods():
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetLocal("$self"),
+                                left=LocalGet("$self"),
                                 right=BinaryOperation(
                                     op="i32.mul",
                                     left=Const(type="i32", val="0"),
@@ -1144,7 +1144,7 @@ def test_data_vector_with_self_getter_methods():
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetLocal("$self"),
+                                left=LocalGet("$self"),
                                 right=BinaryOperation(
                                     op="i32.mul",
                                     left=Const(type="i32", val="1"),
@@ -1161,7 +1161,7 @@ def test_data_vector_with_self_getter_methods():
                     locals=[Local(name="$vector", type="i32")],
                     result=Result(type=None),
                     instructions=[
-                        SetLocal(
+                        LocalSet(
                             name="$vector",
                             val=Call(
                                 name="$Vector.new",
@@ -1176,7 +1176,7 @@ def test_data_vector_with_self_getter_methods():
                             arguments=[
                                 Call(
                                     name="$Vector.getX",
-                                    arguments=[GetLocal(name="$vector")],
+                                    arguments=[LocalGet(name="$vector")],
                                 )
                             ],
                         ),
@@ -1185,7 +1185,7 @@ def test_data_vector_with_self_getter_methods():
                             arguments=[
                                 Call(
                                     name="$Vector.getY",
-                                    arguments=[GetLocal(name="$vector")],
+                                    arguments=[LocalGet(name="$vector")],
                                 )
                             ],
                         ),
@@ -1232,7 +1232,7 @@ def test_data_vector_with_math():
                     result=Result(type="i32"),
                     locals=[],
                     instructions=[
-                        SetGlobal(
+                        GlobalSet(
                             name="$self_pointer",
                             val=Call(
                                 name="$malloc", arguments=[Const(type="i32", val="2")]
@@ -1243,24 +1243,24 @@ def test_data_vector_with_math():
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="0"),
                                 )
                             ),
-                            val=GetLocal(name="$x"),
+                            val=LocalGet(name="$x"),
                         ),
                         Store(
                             type="i32",
                             location=(
                                 BinaryOperation(
                                     op="i32.add",
-                                    left=GetGlobal(name="$self_pointer"),
+                                    left=GlobalGet(name="$self_pointer"),
                                     right=Const(type="i32", val="4"),
                                 )
                             ),
-                            val=GetLocal(name="$y"),
+                            val=LocalGet(name="$y"),
                         ),
-                        GetGlobal(name="$self_pointer"),
+                        GlobalGet(name="$self_pointer"),
                     ],
                 ),
                 Func(
@@ -1276,7 +1276,7 @@ def test_data_vector_with_math():
                                 type="i32",
                                 location=BinaryOperation(
                                     op="i32.add",
-                                    left=GetLocal("$self"),
+                                    left=LocalGet("$self"),
                                     right=BinaryOperation(
                                         op="i32.mul",
                                         left=Const(type="i32", val="1"),
@@ -1288,7 +1288,7 @@ def test_data_vector_with_math():
                                 type="i32",
                                 location=BinaryOperation(
                                     op="i32.add",
-                                    left=GetLocal("$self"),
+                                    left=LocalGet("$self"),
                                     right=BinaryOperation(
                                         op="i32.mul",
                                         left=Const(type="i32", val="1"),
@@ -1306,7 +1306,7 @@ def test_data_vector_with_math():
                     locals=[Local(name="$vector", type="i32")],
                     result=Result(type=None),
                     instructions=[
-                        SetLocal(
+                        LocalSet(
                             name="$vector",
                             val=Call(
                                 name="$Vector.new",
@@ -1321,7 +1321,7 @@ def test_data_vector_with_math():
                             arguments=[
                                 Call(
                                     name="$Vector.getDoubleY",
-                                    arguments=[GetLocal(name="$vector")],
+                                    arguments=[LocalGet(name="$vector")],
                                 )
                             ],
                         ),
@@ -1381,7 +1381,7 @@ def test_data_vector_with_complex_function():
                     params=[Param(type="i32", name="$x"), Param(type="i32", name="$y")],
                     locals=[],
                     instructions=[
-                        SetGlobal(
+                        GlobalSet(
                             name="$self_pointer",
                             val=Call(
                                 name="$malloc", arguments=[Const(type="i32", val="2")]
@@ -1391,21 +1391,21 @@ def test_data_vector_with_complex_function():
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetGlobal(name="$self_pointer"),
+                                left=GlobalGet(name="$self_pointer"),
                                 right=Const(type="i32", val="0"),
                             ),
-                            val=GetLocal(name="$x"),
+                            val=LocalGet(name="$x"),
                         ),
                         Store(
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetGlobal(name="$self_pointer"),
+                                left=GlobalGet(name="$self_pointer"),
                                 right=Const(type="i32", val="4"),
                             ),
-                            val=GetLocal(name="$y"),
+                            val=LocalGet(name="$y"),
                         ),
-                        GetGlobal(name="$self_pointer"),
+                        GlobalGet(name="$self_pointer"),
                     ],
                     result=Result(type="i32"),
                 ),
@@ -1427,7 +1427,7 @@ def test_data_vector_with_complex_function():
                                         type="i32",
                                         location=BinaryOperation(
                                             op="i32.add",
-                                            left=GetLocal(name="$self"),
+                                            left=LocalGet(name="$self"),
                                             right=BinaryOperation(
                                                 op="i32.mul",
                                                 left=Const(type="i32", val="0"),
@@ -1439,7 +1439,7 @@ def test_data_vector_with_complex_function():
                                         type="i32",
                                         location=BinaryOperation(
                                             op="i32.add",
-                                            left=GetLocal(name="$other"),
+                                            left=LocalGet(name="$other"),
                                             right=BinaryOperation(
                                                 op="i32.mul",
                                                 left=Const(type="i32", val="0"),
@@ -1454,7 +1454,7 @@ def test_data_vector_with_complex_function():
                                         type="i32",
                                         location=BinaryOperation(
                                             op="i32.add",
-                                            left=GetLocal(name="$self"),
+                                            left=LocalGet(name="$self"),
                                             right=BinaryOperation(
                                                 op="i32.mul",
                                                 left=Const(type="i32", val="1"),
@@ -1466,7 +1466,7 @@ def test_data_vector_with_complex_function():
                                         type="i32",
                                         location=BinaryOperation(
                                             op="i32.add",
-                                            left=GetLocal(name="$other"),
+                                            left=LocalGet(name="$other"),
                                             right=BinaryOperation(
                                                 op="i32.mul",
                                                 left=Const(type="i32", val="1"),
@@ -1490,7 +1490,7 @@ def test_data_vector_with_complex_function():
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetLocal(name="$self"),
+                                left=LocalGet(name="$self"),
                                 right=BinaryOperation(
                                     op="i32.mul",
                                     left=Const(type="i32", val="0"),
@@ -1511,7 +1511,7 @@ def test_data_vector_with_complex_function():
                             type="i32",
                             location=BinaryOperation(
                                 op="i32.add",
-                                left=GetLocal(name="$self"),
+                                left=LocalGet(name="$self"),
                                 right=BinaryOperation(
                                     op="i32.mul",
                                     left=Const(type="i32", val="1"),
@@ -1532,7 +1532,7 @@ def test_data_vector_with_complex_function():
                         Local(type="i32", name="$vectorC"),
                     ],
                     instructions=[
-                        SetLocal(
+                        LocalSet(
                             name="$vectorA",
                             val=Call(
                                 name="$Vector.new",
@@ -1542,7 +1542,7 @@ def test_data_vector_with_complex_function():
                                 ],
                             ),
                         ),
-                        SetLocal(
+                        LocalSet(
                             name="$vectorB",
                             val=Call(
                                 name="$Vector.new",
@@ -1552,13 +1552,13 @@ def test_data_vector_with_complex_function():
                                 ],
                             ),
                         ),
-                        SetLocal(
+                        LocalSet(
                             name="$vectorC",
                             val=Call(
                                 name="$Vector.add",
                                 arguments=[
-                                    GetLocal(name="$vectorA"),
-                                    GetLocal(name="$vectorB"),
+                                    LocalGet(name="$vectorA"),
+                                    LocalGet(name="$vectorB"),
                                 ],
                             ),
                         ),
@@ -1567,7 +1567,7 @@ def test_data_vector_with_complex_function():
                             arguments=[
                                 Call(
                                     name="$Vector.getX",
-                                    arguments=[GetLocal(name="$vectorC")],
+                                    arguments=[LocalGet(name="$vectorC")],
                                 )
                             ],
                         ),
@@ -1576,7 +1576,7 @@ def test_data_vector_with_complex_function():
                             arguments=[
                                 Call(
                                     name="$Vector.getY",
-                                    arguments=[GetLocal(name="$vectorC")],
+                                    arguments=[LocalGet(name="$vectorC")],
                                 )
                             ],
                         ),
@@ -1602,7 +1602,9 @@ def test_simple_trait():
      """
     result = get_wasm(source)
 
-    import prettyprinter; prettyprinter.pprint(result)
+    import prettyprinter
+
+    prettyprinter.pprint(result)
 
     assert_equal_modules(
         result,
@@ -1610,59 +1612,58 @@ def test_simple_trait():
             imports=[],
             instructions=[
                 Func(
-                    name='$Person.new',
+                    name="$Person.new",
                     export=None,
-                    params=[Param(type='i32', name='$age')],
+                    params=[Param(type="i32", name="$age")],
                     locals=[],
                     instructions=[
-                        SetGlobal(
-                            name='$self_pointer',
+                        GlobalSet(
+                            name="$self_pointer",
                             val=Call(
-                                name='$malloc',
-                                arguments=[Const(type='i32', val='2')]
-                            )
+                                name="$malloc", arguments=[Const(type="i32", val="2")]
+                            ),
                         ),
                         Store(
-                            type='i32',
+                            type="i32",
                             location=BinaryOperation(
-                                op='i32.add',
-                                left=GetGlobal(name='$self_pointer'),
-                                right=Const(type='i32', val='0')
+                                op="i32.add",
+                                left=GlobalGet(name="$self_pointer"),
+                                right=Const(type="i32", val="0"),
                             ),
-                            val=GetLocal(name='$age')
+                            val=LocalGet(name="$age"),
                         ),
-                        GetGlobal(name='$self_pointer')
+                        GlobalGet(name="$self_pointer"),
                     ],
-                    result=Result(type='i32')
+                    result=Result(type="i32"),
                 ),
                 Func(
-                    name='$Person.isEqualAge',
+                    name="$Person.isEqualAge",
                     export=None,
                     params=[
-                        Param(type='i32', name='$self'),
-                        Param(type='i32', name='$age')
+                        Param(type="i32", name="$self"),
+                        Param(type="i32", name="$age"),
                     ],
                     locals=[],
                     instructions=[
                         BinaryOperation(
-                            op='i32.eq',
+                            op="i32.eq",
                             left=Load(
-                                type='i32',
+                                type="i32",
                                 location=BinaryOperation(
-                                    op='i32.add',
-                                    left=GetLocal(name='$self'),
+                                    op="i32.add",
+                                    left=LocalGet(name="$self"),
                                     right=BinaryOperation(
-                                        op='i32.mul',
-                                        left=Const(type='i32', val='0'),
-                                        right=Const(type='i32', val='4')
-                                    )
-                                )
+                                        op="i32.mul",
+                                        left=Const(type="i32", val="0"),
+                                        right=Const(type="i32", val="4"),
+                                    ),
+                                ),
                             ),
-                            right=GetLocal(name='$age')
+                            right=LocalGet(name="$age"),
                         )
                     ],
-                    result=Result(type='i32')
-                )
-            ]
-        )
+                    result=Result(type="i32"),
+                ),
+            ],
+        ),
     )

--- a/tests/test_wasm_printing.py
+++ b/tests/test_wasm_printing.py
@@ -9,15 +9,15 @@ from wasm.model import (
     Result,
     Const,
     Local,
-    GetLocal,
-    SetLocal,
+    LocalGet,
+    LocalSet,
     If,
     Drop,
     Return,
     Nop,
     Memory,
-    GetGlobal,
-    SetGlobal,
+    GlobalGet,
+    GlobalSet,
     Global,
     Store,
     Load,
@@ -84,15 +84,15 @@ def test_function_call_with_params_and_locals(snapshot):
                 locals=[Local(type="i32", name="$answer")],
                 export=None,
                 instructions=[
-                    SetLocal(
+                    LocalSet(
                         name="$answer",
                         val=BinaryOperation(
                             op="i32.add",
-                            left=GetLocal(name="$a"),
-                            right=GetLocal(name="$b"),
+                            left=LocalGet(name="$a"),
+                            right=LocalGet(name="$b"),
                         ),
                     ),
-                    GetLocal(name="$answer"),
+                    LocalGet(name="$answer"),
                 ],
             ),
             Func(
@@ -102,14 +102,14 @@ def test_function_call_with_params_and_locals(snapshot):
                 locals=[Local(type="i32", name="$a"), Local(type="i32", name="$b")],
                 result=Result(type=None),
                 instructions=[
-                    SetLocal(name="$a", val=Const(type="i32", val="2")),
-                    SetLocal(name="$b", val=Const(type="i32", val="3")),
+                    LocalSet(name="$a", val=Const(type="i32", val="2")),
+                    LocalSet(name="$b", val=Const(type="i32", val="3")),
                     Call(
                         name="$output_println",
                         arguments=[
                             Call(
                                 name="$add",
-                                arguments=[GetLocal(name="$a"), GetLocal(name="$b")],
+                                arguments=[LocalGet(name="$a"), LocalGet(name="$b")],
                             )
                         ],
                     ),
@@ -266,17 +266,17 @@ def test_globals(snapshot):
                 result=Result(type="i32"),
                 export=None,
                 instructions=[
-                    SetGlobal(
+                    GlobalSet(
                         name="$count",
                         val=(
                             BinaryOperation(
                                 op="i32.add",
-                                left=GetGlobal(name="$count"),
+                                left=GlobalGet(name="$count"),
                                 right=Const(type="i32", val="1"),
                             )
                         ),
                     ),
-                    GetGlobal(name="$count"),
+                    GlobalGet(name="$count"),
                 ],
             ),
         ],

--- a/wasm/model.py
+++ b/wasm/model.py
@@ -66,9 +66,9 @@ class Func(Instruction):
     ( func (param i32) (param i32) (result f64) (local f64) (local i32) ... )
     Absence of result indicates no return value
 
-    Reference locals with `get_local 0`, `get_local 1`, or more readable:
+    Reference locals with `local.get 0`, `local.get 1`, or more readable:
     ( func (param $p1 i32) (param $p2 i32) (result f64) (local $a f64) (local $b i32) ... )
-    Reference locals with `get_local $p1`, `get_local $a`
+    Reference locals with `local.get $p1`, `local.get $a`
     """
 
     name: Optional[str]
@@ -94,20 +94,20 @@ class BinaryOperation(Instruction):
 
 
 @dataclass
-class GetLocal(Instruction):
+class LocalGet(Instruction):
     name: str
 
     def accept(self, visitor: "WasmVisitor"):
-        return visitor.visit_get_local(self)
+        return visitor.visit_local_get(self)
 
 
 @dataclass
-class SetLocal(Instruction):
+class LocalSet(Instruction):
     name: str
     val: Instruction
 
     def accept(self, visitor: "WasmVisitor"):
-        return visitor.visit_set_local(self)
+        return visitor.visit_local_set(self)
 
 
 @dataclass
@@ -169,20 +169,20 @@ class Global(Instruction):
 
 
 @dataclass
-class GetGlobal(Instruction):
+class GlobalGet(Instruction):
     name: str
 
     def accept(self, visitor: "WasmVisitor"):
-        return visitor.visit_get_global(self)
+        return visitor.visit_global_get(self)
 
 
 @dataclass
-class SetGlobal(Instruction):
+class GlobalSet(Instruction):
     name: str
     val: Instruction
 
     def accept(self, visitor: "WasmVisitor"):
-        return visitor.visit_set_global(self)
+        return visitor.visit_global_set(self)
 
 
 @dataclass
@@ -241,11 +241,11 @@ class WasmVisitor:
         raise NotImplementedError()
 
     @abstractmethod
-    def visit_get_local(self, param: GetLocal):
+    def visit_local_get(self, param: LocalGet):
         raise NotImplementedError()
 
     @abstractmethod
-    def visit_set_local(self, local: SetLocal):
+    def visit_local_set(self, local: LocalSet):
         raise NotImplementedError()
 
     @abstractmethod
@@ -289,11 +289,11 @@ class WasmVisitor:
         raise NotImplementedError()
 
     @abstractmethod
-    def visit_get_global(self, get_global: GetGlobal):
+    def visit_global_get(self, global_get: GlobalGet):
         raise NotImplementedError()
 
     @abstractmethod
-    def visit_set_global(self, set_global: SetGlobal):
+    def visit_global_set(self, global_set: GlobalSet):
         raise NotImplementedError()
 
     @abstractmethod

--- a/wasm/printer.py
+++ b/wasm/printer.py
@@ -7,16 +7,16 @@ from .model import (
     Param,
     Const,
     Local,
-    SetLocal,
-    GetLocal,
+    LocalSet,
+    LocalGet,
     Result,
     If,
     Return,
     Drop,
     Nop,
     Memory,
-    SetGlobal,
-    GetGlobal,
+    GlobalSet,
+    GlobalGet,
     Global,
     Import,
     Store,
@@ -129,19 +129,19 @@ class WasmPrinter(WasmVisitor):
     def visit_local(self, local: Local):
         return self.with_indentation(f"(local {local.name} {local.type})")
 
-    def visit_set_local(self, set_local: SetLocal):
-        result = self.with_indentation(f"(set_local {set_local.name}") + "\n"
+    def visit_local_set(self, local_set: LocalSet):
+        result = self.with_indentation(f"(local.set {local_set.name}") + "\n"
 
         self.indentation += 1
-        result += set_local.val.accept(self)
+        result += local_set.val.accept(self)
         self.indentation -= 1
 
         result += self.with_indentation(")") + "\n"
 
         return result
 
-    def visit_get_local(self, get_local: GetLocal):
-        return self.with_indentation(f"(get_local {get_local.name})") + "\n"
+    def visit_local_get(self, local_get: LocalGet):
+        return self.with_indentation(f"(local.get {local_get.name})") + "\n"
 
     def visit_call(self, call: Call):
         result = self.with_indentation("(call\n")
@@ -215,14 +215,14 @@ class WasmPrinter(WasmVisitor):
 
         return result
 
-    def visit_get_global(self, get_global: GetGlobal):
-        return self.with_indentation(f"(global.get {get_global.name})") + "\n"
+    def visit_global_get(self, global_get: GlobalGet):
+        return self.with_indentation(f"(global.get {global_get.name})") + "\n"
 
-    def visit_set_global(self, set_global: SetGlobal):
-        result = self.with_indentation(f"(global.set {set_global.name}") + "\n"
+    def visit_global_set(self, global_set: GlobalSet):
+        result = self.with_indentation(f"(global.set {global_set.name}") + "\n"
 
         self.indentation += 1
-        result += set_global.val.accept(self)
+        result += global_set.val.accept(self)
         self.indentation -= 1
 
         result += self.with_indentation(")") + "\n"


### PR DESCRIPTION
For consistency this PR aligns the codebase with the newest wasm naming convention:

```
;; core instructions
get_local -> local.get
set_local -> local.set
get_global -> global.get
set_global -> global.set
```

https://github.com/WebAssembly/spec/issues/884